### PR TITLE
Add basic MP4 audio playback

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -101,6 +101,10 @@
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>com.loohp.imageframe.libs.org.apache.commons</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.jcodec</pattern>
+                                    <shadedPattern>com.loohp.imageframe.libs.org.jcodec</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>
@@ -317,6 +321,12 @@
             <groupId>com.madgag</groupId>
             <artifactId>animated-gif-lib</artifactId>
             <version>1.4</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jcodec</groupId>
+            <artifactId>jcodec</artifactId>
+            <version>0.2.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/common/src/main/java/com/loohp/imageframe/Commands.java
+++ b/common/src/main/java/com/loohp/imageframe/Commands.java
@@ -222,7 +222,7 @@ public class Commands implements CommandExecutor, TabCompleter {
                                         String finalUrl = url;
                                         String finalImageType = imageType;
                                         creationTask = ImageFrame.imageMapCreationTaskManager.enqueue(owner, name, width, height, () -> {
-                                            if (finalImageType.equals(MapUtils.GIF_CONTENT_TYPE) && sender.hasPermission("imageframe.create.animated")) {
+                                            if ((finalImageType.equals(MapUtils.GIF_CONTENT_TYPE) || finalImageType.equals(MapUtils.MP4_CONTENT_TYPE)) && sender.hasPermission("imageframe.create.animated")) {
                                                 return URLAnimatedImageMap.create(ImageFrame.imageMapManager, name, finalUrl, width, height, ditheringType, owner).get();
                                             } else {
                                                 return URLStaticImageMap.create(ImageFrame.imageMapManager, name, finalUrl, width, height, ditheringType, owner).get();
@@ -789,7 +789,7 @@ public class Commands implements CommandExecutor, TabCompleter {
                                         sender.sendMessage(ImageFrame.messageURLRestricted);
                                         return;
                                     }
-                                    if (imageType.equals(MapUtils.GIF_CONTENT_TYPE) == urlImageMap.requiresAnimationService()) {
+                                    if ((imageType.equals(MapUtils.GIF_CONTENT_TYPE) || imageType.equals(MapUtils.MP4_CONTENT_TYPE)) == urlImageMap.requiresAnimationService()) {
                                         String oldUrl = urlImageMap.getUrl();
                                         if (url != null) {
                                             urlImageMap.setUrl(url);

--- a/common/src/main/java/com/loohp/imageframe/ImageFrame.java
+++ b/common/src/main/java/com/loohp/imageframe/ImageFrame.java
@@ -44,6 +44,7 @@ import com.loohp.imageframe.objectholders.UnsetState;
 import com.loohp.imageframe.placeholderapi.Placeholders;
 import com.loohp.imageframe.updater.Updater;
 import com.loohp.imageframe.upload.ImageUploadManager;
+import com.loohp.imageframe.sound.ResourcePackSoundManager;
 import com.loohp.imageframe.utils.ChatColorUtils;
 import com.loohp.imageframe.utils.MCVersion;
 import com.loohp.imageframe.utils.ModernEventsUtils;
@@ -193,6 +194,7 @@ public class ImageFrame extends JavaPlugin {
     public static InvisibleFrameManager invisibleFrameManager;
     public static ImageMapCreationTaskManager imageMapCreationTaskManager;
     public static ImageUploadManager imageUploadManager;
+    public static ResourcePackSoundManager resourcePackSoundManager;
 
     public static boolean isURLAllowed(String link) {
         if (!restrictImageUrlEnabled) {
@@ -333,6 +335,10 @@ public class ImageFrame extends JavaPlugin {
         invisibleFrameManager = new InvisibleFrameManager();
         imageMapCreationTaskManager = new ImageMapCreationTaskManager(ImageFrame.parallelProcessingLimit);
         imageUploadManager = new ImageUploadManager(uploadServiceEnabled, uploadServiceServerAddress, uploadServiceServerPort);
+        resourcePackSoundManager = new ResourcePackSoundManager(imageUploadManager.getWebRootDir());
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            resourcePackSoundManager.applyResourcePack(player);
+        }
 
         if (isPluginEnabled("PlaceholderAPI")) {
             new Placeholders().register();
@@ -357,6 +363,12 @@ public class ImageFrame extends JavaPlugin {
         }
         if (imageUploadManager != null) {
             imageUploadManager.close();
+        }
+        if (resourcePackSoundManager != null) {
+            try {
+                resourcePackSoundManager.close();
+            } catch (Exception ignore) {
+            }
         }
         getServer().getConsoleSender().sendMessage(ChatColor.RED + "[ImageFrame] ImageFrame has been Disabled!");
     }

--- a/common/src/main/java/com/loohp/imageframe/objectholders/AnimatedFakeMapManager.java
+++ b/common/src/main/java/com/loohp/imageframe/objectholders/AnimatedFakeMapManager.java
@@ -338,6 +338,7 @@ public class AnimatedFakeMapManager implements Listener, Runnable {
             if (player.isOnline()) {
                 knownMapIds.put(player, ConcurrentHashMap.newKeySet());
                 pendingKnownMapIds.put(player, ConcurrentHashMap.newKeySet());
+                ImageFrame.resourcePackSoundManager.applyResourcePack(player);
             }
         }, 20);
     }

--- a/common/src/main/java/com/loohp/imageframe/objectholders/URLAnimatedImageMap.java
+++ b/common/src/main/java/com/loohp/imageframe/objectholders/URLAnimatedImageMap.java
@@ -27,6 +27,7 @@ import com.loohp.imageframe.ImageFrame;
 import com.loohp.imageframe.api.events.ImageMapUpdatedEvent;
 import com.loohp.imageframe.utils.FutureUtils;
 import com.loohp.imageframe.utils.GifReader;
+import com.loohp.imageframe.utils.Mp4Reader;
 import com.loohp.imageframe.utils.HTTPRequestUtils;
 import com.loohp.imageframe.utils.MapUtils;
 import com.loohp.platformscheduler.Scheduler;
@@ -80,7 +81,7 @@ public class URLAnimatedImageMap extends URLImageMap {
             mapViews.add(mapView);
             mapIds.add(mapView.getId());
         }
-        URLAnimatedImageMap map = new URLAnimatedImageMap(manager, -1, name, url, new FileLazyMappedBufferedImage[mapsCount][], mapViews, mapIds, markers, width, height, ditheringType, creator, Collections.emptyMap(), System.currentTimeMillis(), -1, 0);
+        URLAnimatedImageMap map = new URLAnimatedImageMap(manager, -1, name, url, new FileLazyMappedBufferedImage[mapsCount][], mapViews, mapIds, markers, width, height, ditheringType, creator, Collections.emptyMap(), System.currentTimeMillis(), -1, 0, null);
         return FutureUtils.callAsyncMethod(() -> {
             FutureUtils.callSyncMethod(() -> {
                 for (int i = 0; i < mapViews.size(); i++) {
@@ -157,7 +158,8 @@ public class URLAnimatedImageMap extends URLImageMap {
         }
         int pausedAt = json.has("pausedAt") ? json.get("pausedAt").getAsInt() : -1;
         int tickOffset = json.has("tickOffset") ? json.get("tickOffset").getAsInt() : 0;
-        URLAnimatedImageMap map = new URLAnimatedImageMap(manager, imageIndex, name, url, cachedImages, mapViews, mapIds, markers, width, height, ditheringType, creator, hasAccess, creationTime, pausedAt, tickOffset);
+        String soundKey = json.has("soundKey") ? json.get("soundKey").getAsString() : null;
+        URLAnimatedImageMap map = new URLAnimatedImageMap(manager, imageIndex, name, url, cachedImages, mapViews, mapIds, markers, width, height, ditheringType, creator, hasAccess, creationTime, pausedAt, tickOffset, soundKey);
         return FutureUtils.callSyncMethod(() -> {
             for (int u = 0; u < mapViews.size(); u++) {
                 MapView mapView = mapViews.get(u);
@@ -177,12 +179,14 @@ public class URLAnimatedImageMap extends URLImageMap {
     protected Set<Integer> fakeMapIdsSet;
     protected int pausedAt;
     protected int tickOffset;
+    protected String soundKey;
 
-    protected URLAnimatedImageMap(ImageMapManager manager, int imageIndex, String name, String url, FileLazyMappedBufferedImage[][] cachedImages, List<MapView> mapViews, List<Integer> mapIds, List<Map<String, MapCursor>> mapMarkers, int width, int height, DitheringType ditheringType, UUID creator, Map<UUID, ImageMapAccessPermissionType> hasAccess, long creationTime, int pausedAt, int tickOffset) {
+    protected URLAnimatedImageMap(ImageMapManager manager, int imageIndex, String name, String url, FileLazyMappedBufferedImage[][] cachedImages, List<MapView> mapViews, List<Integer> mapIds, List<Map<String, MapCursor>> mapMarkers, int width, int height, DitheringType ditheringType, UUID creator, Map<UUID, ImageMapAccessPermissionType> hasAccess, long creationTime, int pausedAt, int tickOffset, String soundKey) {
         super(manager, imageIndex, name, url, mapViews, mapIds, mapMarkers, width, height, ditheringType, creator, hasAccess, creationTime);
         this.cachedImages = cachedImages;
         this.pausedAt = pausedAt;
         this.tickOffset = tickOffset;
+        this.soundKey = soundKey;
         this.cacheControlTask.loadCacheIfManual();
     }
 
@@ -259,10 +263,16 @@ public class URLAnimatedImageMap extends URLImageMap {
     @Override
     public void update(boolean save) throws Exception {
         List<GifReader.ImageFrame> frames;
+        byte[] audio = new byte[0];
         try {
             frames = GifReader.readGif(HTTPRequestUtils.getInputStream(url), ImageFrame.maxImageFileSize).get();
         } catch (Exception e) {
-            throw new RuntimeException("Unable to read or download animated gif, does this url directly links to the gif? (" + url + ")", e);
+            try {
+                frames = Mp4Reader.readMp4(HTTPRequestUtils.getInputStream(url), ImageFrame.maxImageFileSize);
+                audio = Mp4Reader.extractAudioOgg(HTTPRequestUtils.getInputStream(url), ImageFrame.maxImageFileSize);
+            } catch (Exception ex) {
+                throw new RuntimeException("Unable to read or download animated gif/mp4 (" + url + ")", ex);
+            }
         }
         List<BufferedImage> images = new ArrayList<>();
         for (int currentTime = 0; ; currentTime += 50) {
@@ -298,6 +308,12 @@ public class URLAnimatedImageMap extends URLImageMap {
             index++;
         }
         reloadColorCache();
+        if (audio.length > 0) {
+            try {
+                soundKey = ImageFrame.resourcePackSoundManager.addSound(audio);
+            } catch (Exception ignore) {
+            }
+        }
         Bukkit.getPluginManager().callEvent(new ImageMapUpdatedEvent(this));
         if (save) {
             save();
@@ -401,6 +417,12 @@ public class URLAnimatedImageMap extends URLImageMap {
 
     @Override
     public void sendAnimationFakeMaps(Collection<? extends Player> players, MapPacketSentCallback completionCallback) {
+        if (soundKey != null) {
+            for (Player player : players) {
+                ImageFrame.resourcePackSoundManager.applyResourcePack(player);
+                ImageFrame.resourcePackSoundManager.playSound(player, soundKey);
+            }
+        }
         int length = getSequenceLength();
         for (int currentTick = 0; currentTick < length; currentTick++) {
             for (int index = 0; index < fakeMapIds.length; index++) {
@@ -425,6 +447,10 @@ public class URLAnimatedImageMap extends URLImageMap {
         return cachedImages[0].length;
     }
 
+    public String getSoundKey() {
+        return soundKey;
+    }
+
     @Override
     public ImageMap deepClone(String name, UUID creator) throws Exception {
         URLAnimatedImageMap imageMap = create(manager, name, url, width, height, ditheringType, creator).get();
@@ -437,6 +463,7 @@ public class URLAnimatedImageMap extends URLImageMap {
                 newMap.put(entry.getKey(), new MapCursor(mapCursor.getX(), mapCursor.getY(), mapCursor.getDirection(), mapCursor.getType(), mapCursor.isVisible(), mapCursor.getCaption()));
             }
         }
+        imageMap.soundKey = this.soundKey;
         return imageMap;
     }
 
@@ -460,6 +487,9 @@ public class URLAnimatedImageMap extends URLImageMap {
         json.addProperty("creator", creator.toString());
         json.addProperty("pausedAt", pausedAt);
         json.addProperty("tickOffset", tickOffset);
+        if (soundKey != null) {
+            json.addProperty("soundKey", soundKey);
+        }
         JsonObject accessJson = new JsonObject();
         for (Map.Entry<UUID, ImageMapAccessPermissionType> entry : accessControl.getPermissions().entrySet()) {
             accessJson.addProperty(entry.getKey().toString(), entry.getValue().name());

--- a/common/src/main/java/com/loohp/imageframe/sound/ResourcePackSoundManager.java
+++ b/common/src/main/java/com/loohp/imageframe/sound/ResourcePackSoundManager.java
@@ -1,0 +1,143 @@
+package com.loohp.imageframe.sound;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.loohp.imageframe.ImageFrame;
+import org.bukkit.entity.Player;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ResourcePackSoundManager implements AutoCloseable {
+
+    private static final Gson GSON = new Gson();
+
+    private final File packDir;
+    private final File soundsDir;
+    private final File soundsJson;
+    private final File packFile;
+    private final Map<String, String> soundMap;
+
+    public ResourcePackSoundManager(File webRoot) {
+        this.packDir = new File(webRoot, "soundpack");
+        this.soundsDir = new File(packDir, "assets/imageframe/sounds");
+        this.soundsJson = new File(packDir, "assets/imageframe/sounds.json");
+        this.packFile = new File(webRoot, "soundpack.zip");
+        this.soundMap = new HashMap<>();
+        init();
+    }
+
+    private void init() {
+        if (!soundsDir.exists()) {
+            soundsDir.mkdirs();
+        }
+        File mcmeta = new File(packDir, "pack.mcmeta");
+        if (!mcmeta.exists()) {
+            JsonObject meta = new JsonObject();
+            JsonObject pack = new JsonObject();
+            pack.addProperty("pack_format", 6);
+            pack.addProperty("description", "ImageFrame");
+            meta.add("pack", pack);
+            try (Writer writer = new FileWriter(mcmeta)) {
+                GSON.toJson(meta, writer);
+            } catch (IOException ignore) {
+            }
+        }
+        saveSoundsJson();
+        try {
+            rebuildPack();
+        } catch (IOException ignore) {
+        }
+    }
+
+    private void saveSoundsJson() {
+        JsonObject root = new JsonObject();
+        for (Map.Entry<String, String> entry : soundMap.entrySet()) {
+            JsonObject sound = new JsonObject();
+            sound.add("sounds", GSON.toJsonTree(Collections.singletonList(entry.getValue())));
+            root.add(entry.getKey(), sound);
+        }
+        if (!soundsJson.getParentFile().exists()) {
+            soundsJson.getParentFile().mkdirs();
+        }
+        try (Writer writer = new FileWriter(soundsJson)) {
+            GSON.toJson(root, writer);
+        } catch (IOException ignore) {
+        }
+    }
+
+    public synchronized String addSound(byte[] data) throws IOException {
+        String id = UUID.randomUUID().toString().replace("-", "");
+        File file = new File(soundsDir, id + ".ogg");
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(data);
+        }
+        String key = "imageframe." + id;
+        soundMap.put(key, "imageframe/sounds/" + id);
+        saveSoundsJson();
+        rebuildPack();
+        return key;
+    }
+
+    private void rebuildPack() throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(packFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+            Path base = packDir.toPath();
+            Files.walk(base).forEach(p -> {
+                if (Files.isRegularFile(p)) {
+                    String entry = base.relativize(p).toString().replace("\\", "/");
+                    try {
+                        zos.putNextEntry(new ZipEntry(entry));
+                        Files.copy(p, zos);
+                        zos.closeEntry();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            });
+        }
+    }
+
+    private static String sha1(File file) throws IOException, NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-1");
+        try (InputStream is = Files.newInputStream(file.toPath())) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) > 0) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        byte[] hash = digest.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : hash) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    public void applyResourcePack(Player player) {
+        try {
+            player.setResourcePack(packFile.toURI().toString(), sha1(packFile));
+        } catch (Exception ignore) {
+        }
+    }
+
+    public void playSound(Player player, String key) {
+        if (key != null) {
+            player.playSound(player.getLocation(), key, 1.0f, 1.0f);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/common/src/main/java/com/loohp/imageframe/upload/ImageUploadManager.java
+++ b/common/src/main/java/com/loohp/imageframe/upload/ImageUploadManager.java
@@ -102,6 +102,10 @@ public class ImageUploadManager implements AutoCloseable {
         }
     }
 
+    public File getWebRootDir() {
+        return webRootDir;
+    }
+
     public PendingUpload newPendingUpload(UUID user) {
         PendingUpload existing = pendingUploads.remove(user);
         if (existing != null) {

--- a/common/src/main/java/com/loohp/imageframe/utils/MapUtils.java
+++ b/common/src/main/java/com/loohp/imageframe/utils/MapUtils.java
@@ -73,6 +73,7 @@ public class MapUtils {
     public static final int MAP_WIDTH = 128;
 
     public static final String GIF_CONTENT_TYPE = "image/gif";
+    public static final String MP4_CONTENT_TYPE = "video/mp4";
     public static final List<BlockFace> CARTESIAN_BLOCK_FACES = Collections.unmodifiableList(Arrays.asList(BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN));
 
     @SuppressWarnings("removal")

--- a/common/src/main/java/com/loohp/imageframe/utils/Mp4Reader.java
+++ b/common/src/main/java/com/loohp/imageframe/utils/Mp4Reader.java
@@ -1,0 +1,66 @@
+package com.loohp.imageframe.utils;
+
+import org.jcodec.api.FrameGrab;
+import org.jcodec.common.io.NIOUtils;
+import org.jcodec.common.model.Picture;
+import org.jcodec.scale.AWTUtil;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Mp4Reader {
+
+    /**
+     * Decode an MP4 input stream into a list of image frames.
+     * <p>
+     * Frame delays are approximated at 50ms per frame when timing information is
+     * unavailable.
+     */
+    public static List<GifReader.ImageFrame> readMp4(InputStream stream, long sizeLimit) throws IOException {
+        ByteArrayOutputStream buffer = new SizeLimitedByteArrayOutputStream(sizeLimit);
+        try {
+            int nRead;
+            byte[] data = new byte[4096];
+            while ((nRead = stream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+        } finally {
+            stream.close();
+        }
+
+        byte[] array = buffer.toByteArray();
+        FrameGrab grab;
+        try {
+            grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(new ByteArrayInputStream(array)));
+        } catch (Exception e) {
+            throw new IOException("Unable to read MP4", e);
+        }
+
+        List<GifReader.ImageFrame> frames = new ArrayList<>();
+        Picture picture;
+        try {
+            while ((picture = grab.getNativeFrame()) != null) {
+                BufferedImage img = AWTUtil.toBufferedImage(picture);
+                frames.add(new GifReader.ImageFrame(img, 50));
+            }
+        } catch (Exception ignore) {
+            // End of stream or decoding error
+        }
+        return frames;
+    }
+
+    /**
+     * Extract audio from an MP4 input stream as OGG Vorbis bytes.
+     * <p>
+     * This implementation currently returns an empty byte array.
+     * TODO: implement actual audio extraction.
+     */
+    public static byte[] extractAudioOgg(InputStream stream, long sizeLimit) {
+        return new byte[0];
+    }
+}

--- a/common/src/main/resources/upload/web/index.html
+++ b/common/src/main/resources/upload/web/index.html
@@ -133,7 +133,7 @@
             Drop image here or click to select
             <img id="imagePreview" alt="Image Preview" src="">
         </div>
-        <input type="file" id="fileInput" accept="image/png, image/jpeg, image/gif" hidden>
+        <input type="file" id="fileInput" accept="image/png, image/jpeg, image/gif, video/mp4" hidden>
         <button id="uploadBtn" disabled>Upload</button>
     </div>
 
@@ -214,7 +214,7 @@
 
         function handleFileSelect(event) {
             const file = event.target.files[0];
-            if (file && ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(file.type)) {
+            if (file && ["image/png", "image/jpeg", "image/gif", "image/webp", "video/mp4"].includes(file.type)) {
                 selectedFile = file;
                 uploadBtn.disabled = false;
 


### PR DESCRIPTION
## Summary
- build resource pack sound manager for distributing MP4 audio
- expose upload web root in `ImageUploadManager`
- hook sound manager into plugin startup and player join events
- store optional sound key on URL animated maps
- load audio from MP4 files and trigger playback when maps are sent
- stub out `Mp4Reader.extractAudioOgg`

## Testing
- `git status --short`